### PR TITLE
Enabled the option to pass a default value and consumer name for requesting line modes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,18 @@
+declare class Chip {
+  constructor(chipNumber: number);
+  constructor(deviceNameOrPath: string);
+}
+
+declare class Line {
+  constructor(chip: Chip, offset: number);
+
+  getValue(): number;
+
+  setValue(value: number): void;
+
+  release(): void;
+
+  requestOutputMode(defaultValue?: number, consumer?: string): void;
+
+  requestInputMode(consumer?: string): void;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ declare class Line {
 
   release(): void;
 
-  requestOutputMode(defaultValue?: number, consumer?: string): void;
+  requestOutputMode(defaultValue?: 0 | 1, consumer?: string): void;
 
   requestInputMode(consumer?: string): void;
 }

--- a/src/line.cc
+++ b/src/line.cc
@@ -58,13 +58,23 @@ NAN_METHOD(Line::setValue) {
 
 NAN_METHOD(Line::requestInputMode) {
   Line *obj = Nan::ObjectWrap::Unwrap<Line>(info.This());
-  if (-1 == gpiod_line_request_input(obj->getNativeLine(), NULL)) 
+  const char *consumer = NULL;
+  v8::Local<v8::Value> consumerName = info[0];
+  if (!consumerName->IsUndefined()) {
+  }
+  if (-1 == gpiod_line_request_input(obj->getNativeLine(), consumer))
     Nan::ThrowError("Unable to request input mode for this line");
 }
 
 NAN_METHOD(Line::requestOutputMode) {
   Line *obj = Nan::ObjectWrap::Unwrap<Line>(info.This());
-  if (-1 == gpiod_line_request_output(obj->getNativeLine(), NULL, 0)) 
+  unsigned int value = 0;
+  v8::Local<v8::Value> defaultValue = info[0];
+  if (!defaultValue->IsUndefined() && defaultValue->IsNumber()) {
+    value = Nan::To<unsigned int>(defaultValue).FromJust();
+  }
+  Nan::Utf8String consumer(info[1]);
+  if (-1 == gpiod_line_request_output(obj->getNativeLine(), *consumer, value))
     Nan::ThrowError("Unable to request output mode for this line");
 }
 

--- a/src/line.cc
+++ b/src/line.cc
@@ -71,7 +71,12 @@ NAN_METHOD(Line::requestOutputMode) {
   unsigned int value = 0;
   v8::Local<v8::Value> defaultValue = info[0];
   if (!defaultValue->IsUndefined() && defaultValue->IsNumber()) {
-    value = Nan::To<unsigned int>(defaultValue).FromJust();
+    unsigned int val = Nan::To<unsigned int>(defaultValue).FromJust();
+    if (val > 1) {
+      Nan::ThrowError("Default value can only be 0 or 1");
+      return;
+    }
+    value = val;
   }
   Nan::Utf8String consumer(info[1]);
   if (-1 == gpiod_line_request_output(obj->getNativeLine(), *consumer, value))

--- a/src/line.cc
+++ b/src/line.cc
@@ -58,11 +58,8 @@ NAN_METHOD(Line::setValue) {
 
 NAN_METHOD(Line::requestInputMode) {
   Line *obj = Nan::ObjectWrap::Unwrap<Line>(info.This());
-  const char *consumer = NULL;
-  v8::Local<v8::Value> consumerName = info[0];
-  if (!consumerName->IsUndefined()) {
-  }
-  if (-1 == gpiod_line_request_input(obj->getNativeLine(), consumer))
+  Nan::Utf8String consumer(info[1]);
+  if (-1 == gpiod_line_request_input(obj->getNativeLine(), *consumer))
     Nan::ThrowError("Unable to request input mode for this line");
 }
 


### PR DESCRIPTION
`requestInputMode` has gained the option to have a consumer name passed along
`requestOutputMode` has gained the option to have a defaultValue (0/1) and a consumer name passed along

In addition I've added a set of typescript definitions.