### PR TITLE
Fix unstable behaviour if pin could not be taken and app continue to …

### DIFF
--- a/src/chip.cc
+++ b/src/chip.cc
@@ -17,13 +17,16 @@ Chip::Chip(const char *device) {
 }
 
 Chip::~Chip() {
+  if ( !chip) return;
   gpiod_chip_close(chip);
+  chip = NULL;
 }
 
 NAN_METHOD(Chip::New) {
   if (info.IsConstructCall()) {
     Nan::Utf8String device(info[0]);
     Chip *obj = new Chip(*device);
+    if ( !obj->chip) return;
     obj->Wrap(info.This());
     info.GetReturnValue().Set(info.This());
   } else {

--- a/src/chip.cc
+++ b/src/chip.cc
@@ -12,31 +12,43 @@ NAN_MODULE_INIT(Chip::Init) {
 }
 
 Chip::Chip(const char *device) {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   chip = gpiod_chip_open_lookup(device);
+  DOUT( "%s %s():%d %p\n", __FILE__, __FUNCTION__, __LINE__, chip);
   if (!chip) Nan::ThrowError("Unable to open device");
 }
 
 Chip::~Chip() {
+  DOUT( "%s %s():%d %p\n", __FILE__, __FUNCTION__, __LINE__, chip);
   if ( !chip) return;
+  DOUT( "%s %s():%d %p\n", __FILE__, __FUNCTION__, __LINE__, chip);
   gpiod_chip_close(chip);
+  DOUT( "%s %s():%d %p\n", __FILE__, __FUNCTION__, __LINE__, chip);
   chip = NULL;
 }
 
 NAN_METHOD(Chip::New) {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   if (info.IsConstructCall()) {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
     Nan::Utf8String device(info[0]);
     Chip *obj = new Chip(*device);
+    DOUT( "%s %s():%d %p\n", __FILE__, __FUNCTION__, __LINE__, obj);
     if ( !obj->chip) return;
+    DOUT( "%s %s():%d %p\n", __FILE__, __FUNCTION__, __LINE__, obj);
     obj->Wrap(info.This());
     info.GetReturnValue().Set(info.This());
   } else {
+    DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
     const int argc = 1;
     v8::Local<v8::Value> argv[argc] = {info[0]};
     v8::Local<v8::Function> cons = Nan::New(constructor);
     info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
   }
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
 }
 
 gpiod_chip *Chip::getNativeChip() {
+  DOUT( "%s %s():%d %p\n", __FILE__, __FUNCTION__, __LINE__, chip);
   return chip;
 }

--- a/src/chip.hh
+++ b/src/chip.hh
@@ -4,6 +4,14 @@
 #include <gpiod.h>
 #include <nan.h>
 
+#define USE_PRINTF 0
+
+#if USE_PRINTF
+#define DOUT(fmt,args...) printf(fmt,##args)
+#else
+#define DOUT(fmt,args...) 
+#endif
+
 class Chip : public Nan::ObjectWrap {
  public:
   static NAN_MODULE_INIT(Init);

--- a/src/line.cc
+++ b/src/line.cc
@@ -18,33 +18,45 @@ NAN_MODULE_INIT(Line::Init) {
 }
 
 Line::Line(Chip *chip, unsigned int pin) {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   line = gpiod_chip_get_line(chip->getNativeChip(), pin);
+  DOUT( "%s %s():%d %p\n", __FILE__, __FUNCTION__, __LINE__, line);
   if (!line) Nan::ThrowError("Unable to open GPIO line ");
 }
 
 Line::~Line() {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   if ( !line) return;
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   gpiod_line_close_chip(line);
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   line = NULL;
 }
 
 NAN_METHOD(Line::New) {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   if (info.IsConstructCall()) {
+    DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
     Chip *chip = Nan::ObjectWrap::Unwrap<Chip>(Nan::To<v8::Object>(info[0]).ToLocalChecked());
     unsigned int pin = Nan::To<unsigned int>(info[1]).FromJust();
     Line *obj = new Line(chip, pin);
+    DOUT( "%s %s(%d):%d %p\n", __FILE__, __FUNCTION__, pin, __LINE__, obj);
     if ( !obj->line) return;
+    DOUT( "%s %s(%d):%d %p->%p\n", __FILE__, __FUNCTION__, pin, __LINE__, obj, obj->line);
     obj->Wrap(info.This());
     info.GetReturnValue().Set(info.This());
   } else {
     const int argc = 1;
+    DOUT( "%s %s():%d !construct\n", __FILE__, __FUNCTION__, __LINE__);
     v8::Local<v8::Value> argv[argc] = {info[0]};
     v8::Local<v8::Function> cons = Nan::New(constructor);
     info.GetReturnValue().Set(Nan::NewInstance(cons, argc, argv).ToLocalChecked());
   }
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
 }
 
 NAN_METHOD(Line::getValue) {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   Line *obj = Nan::ObjectWrap::Unwrap<Line>(info.This());
   if ( !obj->line) {
     Nan::ThrowError( "::getValue() for line==NULL");
@@ -56,6 +68,7 @@ NAN_METHOD(Line::getValue) {
 }
 
 NAN_METHOD(Line::setValue) {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   Line *obj = Nan::ObjectWrap::Unwrap<Line>(info.This());
   if ( !obj->line) {
     Nan::ThrowError( "::setValue() for line==NULL");
@@ -66,6 +79,7 @@ NAN_METHOD(Line::setValue) {
 }
 
 NAN_METHOD(Line::requestInputMode) {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   Line *obj = Nan::ObjectWrap::Unwrap<Line>(info.This());
   if ( !obj->line) {
     Nan::ThrowError( "::requestInputMode() for line==NULL");
@@ -76,6 +90,7 @@ NAN_METHOD(Line::requestInputMode) {
 }
 
 NAN_METHOD(Line::requestOutputMode) {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   Line *obj = Nan::ObjectWrap::Unwrap<Line>(info.This());
   if ( !obj->line) {
       Nan::ThrowError( "::requestOutputMode() for line==NULL");
@@ -90,6 +105,7 @@ NAN_METHOD(Line::requestOutputMode) {
     }
     value = val;
   }
+  DOUT( "%s %s():%d %p\n", __FILE__, __FUNCTION__, __LINE__, obj);
   Nan::Utf8String consumer(info[1]);
   if (-1 == gpiod_line_request_output(obj->getNativeLine(), *consumer, value))
     Nan::ThrowError( "::requestOutputMode() failed");
@@ -98,11 +114,15 @@ NAN_METHOD(Line::requestOutputMode) {
 
 NAN_METHOD(Line::release) {
   Line *obj = Nan::ObjectWrap::Unwrap<Line>(info.This());
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   if ( !obj->getNativeLine()) return;
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   gpiod_line_release(obj->getNativeLine());
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   obj->line = NULL;
 }
 
 gpiod_line *Line::getNativeLine() {
+  DOUT( "%s %s():%d %p\n", __FILE__, __FUNCTION__, __LINE__, line);
   return line;
 }


### PR DESCRIPTION
…use the object.

While using in NodeRed it obviously happens when user put the Line object on the sheet with the wrong pin setting, then fix the issue by changing the pin number.

Additional checks and cleanups are done to prevent SEGV fault in NodeRed while operating with GPIO nodes.
It fixed about 95% of SEGV cases in this module.

There are also second patch that allows user to see the exact line of the SEGV in console.
May be useful, case unstable behaviour is still possible.