### PR TITLE
Feature line flags

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -118,6 +118,17 @@ declare module "node-libgpiod" {
      * @throws error if the line is already reserved
      */
     requestInputMode(consumer?: string): void;
+
+    /**
+     * Reserves the current line as an input with Flags.
+     *
+     * A consumer name can be given to assign a name to the reservation.
+     *
+     * @param consumer an optional consumer name to assign to the reservation
+     * @param flags GPIOD_LINE_REQUEST_FLAG_xxxx as defined in gpiod.h
+     * @throws error if the line is already reserved
+     */
+    requestInputModeFlags(consumer?: string, flags?: number): void;
   }
   
   /**

--- a/src/line.cc
+++ b/src/line.cc
@@ -16,6 +16,15 @@ NAN_MODULE_INIT(Line::Init) {
   Nan::SetPrototypeMethod(tpl, "requestOutputMode", requestOutputMode);
   Nan::SetPrototypeMethod(tpl, "release", release);
 
+  v8::Local<v8::Object> lineFlags = Nan::New<v8::Object>();
+  Nan::Set(lineFlags, Nan::New("GPIOD_LINE_REQUEST_FLAG_OPEN_DRAIN").ToLocalChecked(), Nan::New(GPIOD_LINE_REQUEST_FLAG_OPEN_DRAIN));
+  Nan::Set(lineFlags, Nan::New("GPIOD_LINE_REQUEST_FLAG_OPEN_SOURCE").ToLocalChecked(), Nan::New(GPIOD_LINE_REQUEST_FLAG_OPEN_SOURCE));
+  Nan::Set(lineFlags, Nan::New("GPIOD_LINE_REQUEST_FLAG_ACTIVE_LOW").ToLocalChecked(), Nan::New(GPIOD_LINE_REQUEST_FLAG_ACTIVE_LOW));
+  Nan::Set(lineFlags, Nan::New("GPIOD_LINE_REQUEST_FLAG_BIAS_DISABLE").ToLocalChecked(), Nan::New(GPIOD_LINE_REQUEST_FLAG_BIAS_DISABLE));
+  Nan::Set(lineFlags, Nan::New("GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_DOWN").ToLocalChecked(), Nan::New(GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_DOWN));
+  Nan::Set(lineFlags, Nan::New("GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_UP").ToLocalChecked(), Nan::New(GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_UP));
+  Nan::Set(target, Nan::New("LineFlags").ToLocalChecked(), lineFlags);
+
   constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
   Nan::Set(target, Nan::New("Line").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
 }

--- a/src/line.cc
+++ b/src/line.cc
@@ -13,6 +13,7 @@ NAN_MODULE_INIT(Line::Init) {
   Nan::SetPrototypeMethod(tpl, "getValue", getValue);
   Nan::SetPrototypeMethod(tpl, "setValue", setValue);
   Nan::SetPrototypeMethod(tpl, "requestInputMode", requestInputMode);
+  Nan::SetPrototypeMethod(tpl, "requestInputModeFlags", requestInputModeFlags);
   Nan::SetPrototypeMethod(tpl, "requestOutputMode", requestOutputMode);
   Nan::SetPrototypeMethod(tpl, "release", release);
 

--- a/src/line.cc
+++ b/src/line.cc
@@ -132,6 +132,19 @@ NAN_METHOD(Line::requestInputMode) {
     Nan::ThrowError( "::requestInputMode() failed");
 }
 
+NAN_METHOD(Line::requestInputModeFlags) {
+  DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
+  Line *obj = Nan::ObjectWrap::Unwrap<Line>(info.This());
+  if (!obj->line) {
+    Nan::ThrowError( "::requestInputModeFlags() for line==NULL");
+    return;
+  }
+  Nan::Utf8String consumer(info[0]);
+  int flags = Nan::To<int>(info[1]).FromJust();
+  if (-1 == gpiod_line_request_input_flags(obj->getNativeLine(), *consumer, flags))
+    Nan::ThrowError( "::requestInputModeFlags() failed");
+}
+
 NAN_METHOD(Line::requestOutputMode) {
   DOUT( "%s %s():%d\n", __FILE__, __FUNCTION__, __LINE__);
   Line *obj = Nan::ObjectWrap::Unwrap<Line>(info.This());

--- a/src/line.hh
+++ b/src/line.hh
@@ -24,6 +24,7 @@ class Line : public Nan::ObjectWrap {
   static NAN_METHOD(setValue);
 
   static NAN_METHOD(requestInputMode);
+  static NAN_METHOD(requestInputModeFlags);
   static NAN_METHOD(requestOutputMode);
   static NAN_METHOD(release);
 


### PR DESCRIPTION
Added a new function called `requestInputModeFlags(consumer, flags)`. It enables the configuration of the flags and it is a binding for the library function `gpiod_line_request_input_flags`.
Added a new object called `LineFlags` that include all the flags `GPIOD_LINE_REQUEST_FLAG_xxx` defined in `gpiod.h`.

Example:
```
chip = new gpiod.Chip('gpiochip4');
buttonLine = chip.getLine(BUTTON);
buttonLine.requestInputModeFlags("gpio-basic", gpiod.LineFlags.GPIOD_LINE_REQUEST_FLAG_BIAS_PULL_UP);
```